### PR TITLE
Remove whitespaces & empty lines in responses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let json: OpenAIResponse = serde_json::from_reader(body.reader())?;
 
-    println!("{}", json.choices[0].text);
+    println!("{}", json.choices[0].text.split("\n").map(|s| s.trim()).filter(|s| s.len()>0).collect::<Vec<_>>().join("\n"));
 
     Ok(())
 }


### PR DESCRIPTION
Rusty outputs a lot of whitespaces sometimes:

![image](https://user-images.githubusercontent.com/73352734/194181485-078e8285-67e6-4f8e-9668-6a3c84adca03.png)

Trimming them out would be pretty useful :)